### PR TITLE
Typo in fort dimensions

### DIFF
--- a/example_scripts/fort.js
+++ b/example_scripts/fort.js
@@ -8,7 +8,7 @@ Drone.extend('fort', function(side, height)
 		  side = 18;
 	 if (typeof height == "undefined")
 		  height = 6;
-	 if (height < 4 || side < 10)
+	 if (height < 4 || side < 9)
 		  throw new java.lang.RuntimeException("Forts must be at least 9 wide X 4 tall");
 	 // make sure side is even
 	 if (side%2)


### PR DESCRIPTION
Either it's 9x4 or 10x4. I just patched it to be 9x4 to match the exception.
