### PR TITLE
Add logo.js to example files

### DIFF
--- a/src/main/javascript/drone/logo.js
+++ b/src/main/javascript/drone/logo.js
@@ -177,7 +177,7 @@ Drone.extend('logojs', function(fg, bg) {
         .right().up()
         .box(fg);
 
-    this.move('logojs-start')
+    this.move('logojs-start');
 
     return this;
 });


### PR DESCRIPTION
I thought it would be fitting to include a giant JS logo as an example. It's 100x100x1 and there's also a 'cube' function that produces a four-sided cube.

Here's a screenshot of it in-game:

![giant JS logo by rupl](http://fourkitchens.com/sites/default/files/blog/lead-images/scriptscraft-js_0.jpg)
