### PR TITLE
More efficient box0()

### DIFF
--- a/src/main/javascript/drone/drone.js
+++ b/src/main/javascript/drone/drone.js
@@ -431,7 +431,18 @@ var Drone = Drone || {
         return this.cuboidX(bm[0],bm[1],w,h,d);
     };
     Drone.prototype.cuboid0 = function(block,w,h,d){
-        return this.cuboid(block,w,h,d).fwd().right().cuboid(0,w-2,h,d-2).back().left();
+        this.chkpt('start_point');
+        
+        // Front wall
+        this.cuboid(block, w, h, 1);
+        // Left wall
+        this.cuboid(block, 1, h, d);
+        // Right wall
+        this.right(w-1).cuboid(block, 1, h, d).left(w-1);
+        // Back wall
+        this.fwd(d-1).cuboid(block, w, h, 1);
+        
+        return this.move('start_point');
     };
     Drone.prototype.door = function(door){
         if (typeof door == "undefined"){


### PR DESCRIPTION
Infinitely faster box0() function.
Box has to create every block inside the space specified, however, box0() only builds walls around things so seems sensible that it should do less work.
However, under the old functions way of doing things it did almost twice as much work.
For small objects this isn't noticed very much, however it can have a big impact on performance!

My use case for this was a 500 wide, 70 high and 500 deep iron wall I wanted to act as the city wall. Trying to make this resulted in 2 odd effects. I first made one wall by calling box(42, 250, 70, 1) and laying it out myself. This took a few seconds. Then I decided to save time I would fly to the edge and create it with box0(). box0(42, 500, 70, 500) completely froze minecraft and slowed my computer. It then preceded to take 20 minutes before I decided to give up and close the server.
After restarting it I had a semi complete giant "solid" block. This made me dig into the Drones code.

Getting to the point: with the old way of doing things a GIANT wall takes over 20 minutes to make. this new version takes under 10 seconds.

(explanation not technically needed just wanted to demonstrate it does make a massive difference)
