### PR TITLE
Add blocks added with 1.6, DRY up color variation setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ target
 *.js#
 *.iml
 *.idea
+.DS_Store
 build.local.properties

--- a/docs/api.md
+++ b/docs/api.md
@@ -349,12 +349,12 @@ Example
 -------
 To create a black structure 4 blocks wide, 9 blocks tall and 1 block long...
     
-    box(blocks.black, 4, 9, 1);
+    box(blocks.wool.black, 4, 9, 1);
 
 ... or the following code does the same but creates a variable that can be used for further methods...
 
     var drone = new Drone();
-    drone.box(blocks.black, 4, 9, 1);
+    drone.box(blocks.wool.black, 4, 9, 1);
 
 ![box example 1](img/boxex1.png)
     
@@ -395,8 +395,8 @@ Example
 -------
 Construct a rainbow-colored road 100 blocks long...
 
-    var rainbowColors = [blocks.red, blocks.orange, blocks.yellow, blocks.lime,
-                         blocks.lightblue, blocks.blue, blocks.purple];
+    var rainbowColors = [blocks.wool.red, blocks.wool.orange, blocks.wool.yellow, blocks.wool.lime,
+                         blocks.wool.lightblue, blocks.wool.blue, blocks.wool.purple];
     
     boxa(rainbowColors,7,1,30);
 
@@ -920,6 +920,23 @@ To create a 2-line high message using glowstone...
 
 [imgbt1]: img/blocktype1.png
 
+Drone.rainbow() method
+======================
+Creates a Rainbow.
+
+Parameters
+----------
+
+ * radius (optional - default:18) - The radius of the rainbow
+
+Example
+-------
+    
+    var d = new Drone();
+    d.rainbow(30);
+
+![rainbow example](img/rainbowex1.png)
+
 Blocks Module
 =============
 You hate having to lookup [Data Values][dv] when you use ScriptCraft's Drone() functions. So do I.
@@ -932,8 +949,35 @@ Examples
     box( blocks.sand, 3, 2, 1 ); // creates a block of sand 3 wide x 2 high x 1 long
     box( blocks.wool.green, 2 ); // creates a block of green wool 2 blocks wide
 
-In addition, each of the wool colors is also available as a block property so you can use either
-`blocks.wool.green` or the more concise `blocks.green`. There's also a convenience array `blocks.rainbow` which is an array of the 7 colors of the rainbow (or closest approximations). 
+In addition, there's a convenience array `blocks.rainbow` which is an array of the 7 colors of the rainbow (or closest approximations).
+
+Drone.spiral_stairs() method
+============================
+Constructs a spiral staircase with slabs at each corner.
+
+Parameters
+----------
+
+ * stairBlock - The block to use for stairs, should be one of the following...
+   - 'oak'
+   - 'spruce'
+   - 'birch'
+   - 'jungle'
+   - 'cobblestone'
+   - 'brick'
+   - 'stone'
+   - 'nether'
+   - 'sandstone'
+   - 'quartz'
+ * flights - The number of flights of stairs to build.
+
+![Spiral Staircase](img/spiralstair1.png)
+
+Example
+-------
+To construct a spiral staircase 5 floors high made of oak...
+
+    spiral_stairs('oak', 5);
 
 Drone.sphere() method
 =====================
@@ -1012,51 +1056,6 @@ To create a glass 'north' hemisphere with a radius of 20 blocks...
     hemisphere0(blocks.glass, 20, 'north');
 
 ![hemisphere example](img/hemisphereex2.png)
-
-Drone.rainbow() method
-======================
-Creates a Rainbow.
-
-Parameters
-----------
-
- * radius (optional - default:18) - The radius of the rainbow
-
-Example
--------
-    
-    var d = new Drone();
-    d.rainbow(30);
-
-![rainbow example](img/rainbowex1.png)
-
-Drone.spiral_stairs() method
-============================
-Constructs a spiral staircase with slabs at each corner.
-
-Parameters
-----------
-
- * stairBlock - The block to use for stairs, should be one of the following...
-   - 'oak'
-   - 'spruce'
-   - 'birch'
-   - 'jungle'
-   - 'cobblestone'
-   - 'brick'
-   - 'stone'
-   - 'nether'
-   - 'sandstone'
-   - 'quartz'
- * flights - The number of flights of stairs to build.
-
-![Spiral Staircase](img/spiralstair1.png)
-
-Example
--------
-To construct a spiral staircase 5 floors high made of oak...
-
-    spiral_stairs('oak', 5);
 
 Classroom Module
 ================

--- a/src/main/javascript/drone/blocks.js
+++ b/src/main/javascript/drone/blocks.js
@@ -11,8 +11,7 @@ Examples
     box( blocks.sand, 3, 2, 1 ); // creates a block of sand 3 wide x 2 high x 1 long
     box( blocks.wool.green, 2 ); // creates a block of green wool 2 blocks wide
 
-In addition, each of the wool colors is also available as a block property so you can use either
-`blocks.wool.green` or the more concise `blocks.green`. There's also a convenience array `blocks.rainbow` which is an array of the 7 colors of the rainbow (or closest approximations). 
+Color aliased properties that were a direct descendant of the blocks object are no longer used to avoid confusion with carpet and stained clay blocks. In addition, there's a convenience array `blocks.rainbow` which is an array of the 7 colors of the rainbow (or closest approximations).
 
 ***/
 var blocks = {
@@ -60,22 +59,7 @@ var blocks = {
     piston: 33,
     piston_extn: 34,
     wool: {
-        white: 35,
-        orange: '35:1',
-        magenta: '35:2',
-        lightblue: '35:3',
-        yellow: '35:4',
-        lime: '35:5',
-        pink: '35:6',
-        gray: '35:7',
-        lightgray: '35:8',
-        cyan: '35:9',
-        purple: '35:10',
-        blue: '35:11',
-        brown: '35:12',
-        green: '35:13',
-        red: '35:14',
-        black: '35:15'
+      white: 35 // All other colors added below
     },
     dandelion: 37,
     flower_yellow: 37,
@@ -165,7 +149,7 @@ var blocks = {
     mycelium: 110,
     lily_pad: 111,
     nether: 112,
-    neter_fence: 113,
+    nether_fence: 113,
     netherwart: 115,
     table_enchantment: 116,
     brewing_stand: 117,
@@ -231,19 +215,60 @@ var blocks = {
     hopper: 154,
     quartz: 155,
     rail_activator: 157,
-    dropper: 158
+    dropper: 158,
+    stained_clay: {
+      white: 159 // All other colors added below
+    },
+    hay: 170,
+    carpet: {
+      white: 171 // All other colors added below
+    },
+    hardened_clay: 172,
+    coal_block: 173
 };
-// make colors top level for convenience
-for (var c  in blocks.wool){
-    blocks[c] = blocks.wool[c];
-}
-/*
-  rainbow colors - a convenience
-*/
-blocks.rainbow = [blocks.red, 
-                  blocks.orange, 
-                  blocks.yellow, 
-                  blocks.lime, 
-                  blocks.lightblue, 
-                  blocks.blue, 
-                  blocks.purple];
+
+(function() {
+  // Add all available colors to colorized block collections
+
+  var colors = {
+    orange: ':1',
+    magenta: ':2',
+    lightblue: ':3',
+    yellow: ':4',
+    lime: ':5',
+    pink: ':6',
+    gray: ':7',
+    lightgray: ':8',
+    cyan: ':9',
+    purple: ':10',
+    blue: ':11',
+    brown: ':12',
+    green: ':13',
+    red: ':14',
+    black: ':15'
+  };
+  var colorized_blocks = ["wool", "stained_clay", "carpet"];
+
+  for (var i = 0, len = colorized_blocks.length; i < len; i++) {
+    var block = colorized_blocks[i],
+        data_value = blocks[block].white;
+
+    for (var color in colors) {
+      blocks[block][color] = data_value + colors[color];
+    }
+  };
+
+  /*
+    rainbow colors - a convenience
+    Color aliased properties that were a direct descendant of the blocks
+    object are no longer used to avoid confusion with carpet and stained
+    clay blocks.
+  */
+  blocks.rainbow = [blocks.wool.red,
+                    blocks.wool.orange,
+                    blocks.wool.yellow,
+                    blocks.wool.lime,
+                    blocks.wool.lightblue,
+                    blocks.wool.blue,
+                    blocks.wool.purple];
+})();

--- a/src/main/javascript/drone/blocktype.js
+++ b/src/main/javascript/drone/blocktype.js
@@ -332,7 +332,7 @@ To create a 2-line high message using glowstone...
         this.chkpt('blocktext');
 
         if (typeof fg == "undefined")
-            fg = blocks.black;
+            fg = blocks.wool.black;
 
         var bmfg = this._getBlockIdAndMeta(fg);
         var bmbg = null;

--- a/src/main/javascript/drone/drone.js
+++ b/src/main/javascript/drone/drone.js
@@ -122,12 +122,12 @@ Example
 -------
 To create a black structure 4 blocks wide, 9 blocks tall and 1 block long...
     
-    box(blocks.black, 4, 9, 1);
+    box(blocks.wool.black, 4, 9, 1);
 
 ... or the following code does the same but creates a variable that can be used for further methods...
 
     var drone = new Drone();
-    drone.box(blocks.black, 4, 9, 1);
+    drone.box(blocks.wool.black, 4, 9, 1);
 
 ![box example 1](img/boxex1.png)
     
@@ -168,8 +168,8 @@ Example
 -------
 Construct a rainbow-colored road 100 blocks long...
 
-    var rainbowColors = [blocks.red, blocks.orange, blocks.yellow, blocks.lime,
-                         blocks.lightblue, blocks.blue, blocks.purple];
+    var rainbowColors = [blocks.wool.red, blocks.wool.orange, blocks.wool.yellow, blocks.wool.lime,
+                         blocks.wool.lightblue, blocks.wool.blue, blocks.wool.purple];
     
     boxa(rainbowColors,7,1,30);
 


### PR DESCRIPTION
This cleans up the addition of color variations now that stained_clay and carpet use the same color modifier. This makes it easier to add new blocks in the future that use the same color values by simply adding the property name to extend them onto within the colorized_blocks array inside the closure. Other changes of note:
- All of the new blocks (hay, hardened clay, coal block, etc.) have been added.
- Fixed a typo in nether_fence.
- Removed direct descendant color aliases now that there are 3 block types with color variations.
- Updated all references to shorthand color aliases to use the full-syntax wool properties.
