### PR TITLE
Integrate the CoffeeScript Compiler for .coffee files

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -38,6 +38,11 @@
 
     <echo>Creating default ops.txt for your user</echo>
     <echo message="${op.name}" file="${minecraft.dir}/ops.txt" />
+  	
+    <echo>Retrieving Coffeescript compiler</echo>
+  	<mkdir dir="${minecraft.dir}/js-plugins/core" />
+    <get src="https://raw.github.com/jashkenas/coffee-script/master/extras/coffee-script.js"
+         dest="${minecraft.dir}/js-plugins/core/_coffeescript.js"/>  	
   </target>
 
   <target name="run" depends="server-setup, package, update-live-cb" description="Starts Bukkit with ScriptCraft">

--- a/src/main/java/net/walterhiggins/scriptcraft/ScriptCraftPlugin.java
+++ b/src/main/java/net/walterhiggins/scriptcraft/ScriptCraftPlugin.java
@@ -98,7 +98,12 @@ public class ScriptCraftPlugin extends JavaPlugin implements Listener
             this.engine.put("__plugin",this);
             this.engine.put("__script",boot.getCanonicalPath().replaceAll("\\\\","/"));
             reader = new FileReader(boot);
-            this.engine.eval(reader);  
+            this.engine.eval(reader);
+            
+            // Load the CoffeeScript compiler
+            File coffeescript = new File(JS_PLUGINS_DIR + "/core/_coffeescript.js");
+            this.engine.eval(new FileReader(coffeescript));
+            
         }catch(Exception e){
             e.printStackTrace();
         }finally {
@@ -147,7 +152,13 @@ public class ScriptCraftPlugin extends JavaPlugin implements Listener
             javascriptCode = "command()";
             this.engine.put("__cmdArgs",args);
             result = true;
+        } else if (cmd.getName().equalsIgnoreCase("coffee")) {
+        	for (int i = 0;i < args.length; i++)
+                javascriptCode += args[i] + " ";
+        	javascriptCode = "eval(CoffeeScript.compile(\""+javascriptCode+"\", {bare: true}))";
+        	result = true;
         }
+        
         if (result){
             this.engine.put("self",sender);
             try{

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -11,7 +11,12 @@ commands:
       description: run a javascript plugin command.
       usage: /<command> command-name command-parameters
       permission: scriptcraft.proxy
-      permission-message: You don't have <permission> permission. 
+      permission-message: You don't have <permission> permission.
+   coffee:
+      description: Evaluate coffeescript.
+      usage: /<command> Coffeescript code
+      permission: scriptcraft.evaluate
+      permission-message: You don't have <permission> permission.
 
 permissions:
    scriptcraft.*:


### PR DESCRIPTION
Simple integration of CoffeeScript support. The code uses the JavaScript implementation of the CoffeeScript compiler. All *.coffee files get compiled to JavaScript just before eval(). Additionaly a new command named /coffe is introduced to run CoffeeScript code straight in the Minecraft console.
