### PR TITLE
Default parameter fix in chessboard and skyscraper

### DIFF
--- a/src/main/javascript/drone/contrib/chessboard.js
+++ b/src/main/javascript/drone/contrib/chessboard.js
@@ -9,8 +9,10 @@
 */
 Drone.extend("chessboard", function(whiteBlock, blackBlock, width, depth) {
     this.chkpt('chessboard-start');
-    width = width || 8;
-    depth = depth || width;
+    if (typeof width == "undefined")
+        width = 8;
+    if (typeof depth == "undefined")
+        depth = width;
     blackBlock = blackBlock || blocks.wool.black;
     whiteBlock = whiteBlock || blocks.wool.white;
 

--- a/src/main/javascript/drone/contrib/skyscraper-example.js
+++ b/src/main/javascript/drone/contrib/skyscraper-example.js
@@ -1,5 +1,6 @@
 Drone.extend('skyscraper',function(floors){
-    floors = floors || 10;
+    if (typeof floors == "undefined")
+        floors = 10;
     this.chkpt('skyscraper');
     for (var i = 0;i < floors; i++)
     {


### PR DESCRIPTION
Default width, height and floor parameters were not properly handled by
the "||" operator.
