### PR TITLE
Use Bukkit's ChatColor class for more reliable output.

### DIFF
--- a/src/main/javascript/utils/text.js
+++ b/src/main/javascript/utils/text.js
@@ -3,30 +3,34 @@ String class extensions
 -----------------------
 The following chat-formatting methods are added to the javascript String class..
 
- * black()
- * darkblue()
- * blue()
- * darkgreen()
- * darkaqua()
- * darkred()
- * purple()
- * gold()
- * gray()
- * darkgray()
- * indigo()
- * brightgreen()
- * green()
- * aqua()
- * red()
- * pink()
- * yellow()
- * white()
- * bold()
- * random()
- * strike()
- * underline()
- * italic()
- * reset()
+    * aqua()
+    * black()
+    * blue()
+    * bold()
+    * brightgreen()
+    * darkaqua()
+    * darkblue()
+    * darkgray()
+    * darkgreen()
+    * purple()
+    * darkpurple()
+    * darkred()
+    * gold()
+    * gray()
+    * green()
+    * italic()
+    * lightpurple()
+    * indigo()
+    * green()
+    * red()
+    * pink()
+    * yellow()
+    * white()
+    * strike()
+    * random()
+    * magic()
+    * underline()
+    * reset()
 
 Example
 -------
@@ -38,35 +42,40 @@ Example
 
 ***/
 (function(){
+    var c = org.bukkit.ChatColor;
     var formattingCodes = {
-        black: 0,
-        darkblue: 1,
-        blue: 1,
-        darkgreen: 2,
-        darkaqua: 3,
-        darkred: 4,
-        purple: 5,
-        gold: 6,
-        gray: 7,
-        darkgray: 8,
-        indigo: 9,
-        brightgreen: 'a',
-        green: 'a',
-        aqua: 'b',
-        red: 'c',
-        pink: 'd',
-        yellow: 'e',
-        white: 'f',
-        bold: 'l',
-        random:'k',
-        strike: 'm',
-        underline: 'n',
-        italic: 'o',
-        reset: 'r'
+        aqua: c.AQUA,
+        black: c.BLACK,
+        blue: c.BLUE,
+        bold: c.BOLD,
+        brightgreen: c.GREEN,
+        darkaqua: c.DARK_AQUA,
+        darkblue: c.DARK_BLUE,
+        darkgray: c.DARK_GRAY,
+        darkgreen: c.DARK_GREEN,
+        purple: c.LIGHT_PURPLE,
+        darkpurple: c.DARK_PURPLE,
+        darkred: c.DARK_RED,
+        gold: c.GOLD,
+        gray: c.GRAY,
+        green: c.GREEN,
+        italic: c.ITALIC,
+        lightpurple: c.LIGHT_PURPLE,
+        indigo: c.BLUE,
+        green: c.GREEN,
+        red: c.RED,
+        pink: c.LIGHT_PURPLE,
+        yellow: c.YELLOW,
+        white: c.WHITE,
+        strike: c.STRIKETHROUGH,
+        random: c.MAGIC,
+        magic: c.MAGIC,
+        underline: c.UNDERLINE,
+        reset: c.RESET
     };
     for (var method in formattingCodes){
-        String.prototype[method] = function(m,c){
-            return function(){ return "§"+c + this;};
-        }(method,formattingCodes[method]);
+        String.prototype[method] = function(c){
+            return function(){return c+this;};
+        }(formattingCodes[method]);
     }
 }());


### PR DESCRIPTION
This will fix some console output in Windows (maybe even other) command prompts (will add a screenshot later), and pretty much future-proofs any formatting code changes.
Also, I cleaned up the String.prototype[method] function by removing the unused "method" parameter.

I have retained the previous colors and used them as aliases.

Aliases:
- brightgreen -> green
- pink -> lightpurple
- indigo -> blue
- purple -> darkpurple
- random -> magic

Adds:
- lightpurple
- darkpurple
- magic
- darkgreen
- green
