### PR TITLE
fix typo in sapling/birch

### DIFF
--- a/src/main/javascript/modules/blocks.js
+++ b/src/main/javascript/modules/blocks.js
@@ -33,7 +33,7 @@ var blocks = {
     sapling: {
         oak: 6,
         spruce: '6:1',
-        birch: '62:2',
+        birch: '6:2',
         jungle: '6:3'
     },
     bedrock: 7,


### PR DESCRIPTION
Looks like a small typo in the blocks definitions. This should fix it. Looking forward to playing with ScriptCraft with my kids :)
