### PR TITLE
Fix require() to work with index.js

### DIFF
--- a/src/main/js/lib/require.js
+++ b/src/main/js/lib/require.js
@@ -244,7 +244,9 @@ When resolving module names to file paths, ScriptCraft uses the following rules.
     try {
       compiledWrapper = eval(code);
     } catch (e) {
-      throw 'Error:' + e + ' while evaluating module ' + canonizedFilename;
+      throw new Error( "Error evaluating module " + path
+        + " at " + canonizedFilename + " line #" + e.lineNumber
+        + ". Error was: " + e.message, canonizedFilename, e.lineNumber );
     }
     var __dirname = '' + file.parentFile.canonicalPath;
     var parameters = [
@@ -259,7 +261,9 @@ When resolving module names to file paths, ScriptCraft uses the following rules.
         .apply(moduleInfo.exports,  /* this */
                parameters);   
     } catch (e) {
-      throw 'Error:' + e + ' while executing module ' + canonizedFilename;
+      throw new Error( "Error executing module " + path
+        + " at " + canonizedFilename + " line #" + e.lineNumber
+        + ". Error was: " + e.message, canonizedFilename, e.lineNumber )
     }
     if ( hooks ) { 
       hooks.loaded( canonizedFilename );


### PR DESCRIPTION
Having require( 'directoryname' ) automatically load 'directoryname/index.js' is a very handy shortcut, but it doesn't actually work due to what looks like a typo..

Fortunately it's an easy fix!

Also, thanks for ScriptCraft, we're going to be doing some VERY cool stuff with it.  ;)
