### PR TITLE
Improve bkEventExecutor interface implementation

### DIFF
--- a/src/main/js/lib/events.js
+++ b/src/main/js/lib/events.js
@@ -121,11 +121,11 @@ exports.on = function(
   handlerList = eventType.getHandlerList( );
 
   var result = { };
-  eventExecutor = new bkEventExecutor( ) {
+  eventExecutor = new bkEventExecutor( {
     execute: function( l, evt ) {
       handler.call( result, evt );
     } 
-  };
+  } );
   /* 
    wph 20130222 issue #64 bad interaction with Essentials plugin
    if another plugin tries to unregister a Listener (not a Plugin or a RegisteredListener)


### PR DESCRIPTION
What was done before isn't valid JS; This does the same thing, while keeping the JS syntax valid.

In short, while I was working on my JSC, my buildscripts couldn't minify events.js because the syntax was invalid. After some googling, I decided to try doing what I have proposed in the pull request, and so far from what I'm looking at, it works exactly the same, while keeping the JS syntax valid.
