### PR TITLE
Added rscall as an easy way to create redstone callbacks

### DIFF
--- a/src/main/js/plugins/drone/contrib/rscall.js
+++ b/src/main/js/plugins/drone/contrib/rscall.js
@@ -22,6 +22,8 @@ var Drone = require('../drone').Drone;
  * (todo: should I be looking for block breaks at this location and removing callbacks?)
  */
 
+var utils = require('utils');
+
 // An object which stores the registered rscalls for later rsremove
 var rsRemoveFuncs = {};
 

--- a/src/main/js/plugins/drone/contrib/rscall.js
+++ b/src/main/js/plugins/drone/contrib/rscall.js
@@ -1,0 +1,53 @@
+var Drone = require('../drone').Drone;
+
+/************************************************************************
+ *
+ * Redstone events are world-wide, and sometimes you want an easy way to respond
+ * to just one button with something.  This drone extension does this!  To use,
+ * look at the button, switch, pressure plate, etc., that you would like to
+ * make do something.  Then, enter:
+ *
+ *   /js new Drone().rscall(function(event){ MY CODE HERE });
+ *
+ * For example,
+ *
+ *   /js new Drone().rscall(function(event){ console.log("My button was pressed!"); });
+ *
+ * You can also chain this with other Drone() commands in order to set up callbacks
+ * as part of a larger construction.
+ *
+ * rscall(callback) will call the callback if a redstone event happens on a block at the location of the drone
+ * rsremove will remove all callbacks added with rscall from the location of the drone
+ *
+ * (todo: should I be looking for block breaks at this location and removing callbacks?)
+*/
+
+var rsRemoveFuncs = {};
+
+function locToStr(x,y,z) { return ""+x+","+y+","+z; }
+
+Drone.extend("rscall", function( callback ) {
+    var newCallback = function(x,y,z){
+                    return function(event) { if (event.block.location.blockX == x &&
+                                            event.block.location.blockY == y &&
+                                            event.block.location.blockZ == z) callback(event); }}(this.x,this.y,this.z);
+    var locStr = locToStr(this.x,this.y,this.z);
+    if (!(locStr in rsRemoveFuncs)) {
+        rsRemoveFuncs[locStr] = [];
+    }
+    rsRemoveFuncs[locStr].push(events.blockRedstone(newCallback));
+
+  return this;
+});
+
+Drone.extend("rsremove", function( ) {
+    var locStr = locToStr(this.x,this.y,this.z);
+    var removeList = rsRemoveFuncs[locToStr(this.x, this.y, this.z)];
+    if (removeList) {
+        for (var i = 0; i < removeList.length; ++i) {
+            removeList[i].unregister();
+        }
+    }
+
+    return this;
+});

--- a/src/main/js/plugins/drone/contrib/rscall.js
+++ b/src/main/js/plugins/drone/contrib/rscall.js
@@ -20,29 +20,34 @@ var Drone = require('../drone').Drone;
  * rsremove will remove all callbacks added with rscall from the location of the drone
  *
  * (todo: should I be looking for block breaks at this location and removing callbacks?)
-*/
+ */
 
+// An object which stores the registered rscalls for later rsremove
 var rsRemoveFuncs = {};
 
-function locToStr(x,y,z) { return ""+x+","+y+","+z; }
+Drone.extend("rscall", function (callback) {
+    var newCallback = function (x, y, z) {
+        return function (event) {
+            if (event.block.location.blockX == x &&
+                event.block.location.blockY == y &&
+                event.block.location.blockZ == z) callback(event);
+        }
+    }(this.x, this.y, this.z);
 
-Drone.extend("rscall", function( callback ) {
-    var newCallback = function(x,y,z){
-                    return function(event) { if (event.block.location.blockX == x &&
-                                            event.block.location.blockY == y &&
-                                            event.block.location.blockZ == z) callback(event); }}(this.x,this.y,this.z);
-    var locStr = locToStr(this.x,this.y,this.z);
+    var locStr = utils.locationToString(new org.bukkit.Location(this.world, this.x, this.y, this.z));
     if (!(locStr in rsRemoveFuncs)) {
+        // First time for this location... create an empty array to store locations
         rsRemoveFuncs[locStr] = [];
     }
+    // Add callback to struct keyed by location string and stored in array
     rsRemoveFuncs[locStr].push(events.blockRedstone(newCallback));
 
-  return this;
+    return this;
 });
 
-Drone.extend("rsremove", function( ) {
-    var locStr = locToStr(this.x,this.y,this.z);
-    var removeList = rsRemoveFuncs[locToStr(this.x, this.y, this.z)];
+Drone.extend("rsremove", function () {
+    var locStr = utils.locationToString(new org.bukkit.Location(this.world, this.x, this.y, this.z));
+    var removeList = rsRemoveFuncs[locStr];
     if (removeList) {
         for (var i = 0; i < removeList.length; ++i) {
             removeList[i].unregister();


### PR DESCRIPTION
This adds a drone command in contrib that lets you set a redstone callback that is specific to the location of the Drone.  This allows something like "/js new Drone().rscall(function(event){console.log("My button was pressed!");});" and the console message will be displayed if and only if the block at the location of the Drone at that time has its redstone state changed.

(This is the same as the previous pull request, but now I've figured out github branching so contains no other extraneous changes.)