### PR TITLE
Added additional utilities for starting drones and getting world object

### DIFF
--- a/src/main/js/modules/utils/utils.js
+++ b/src/main/js/modules/utils/utils.js
@@ -214,6 +214,38 @@ exports.getMousePos = function( player ) {
   return targetedBlock.location;
 };
 /************************************************************************
+### utils.getWorld() function
+
+Given the name of a world, this function returns the world object.  Useful
+ for making some commands easier to type.
+
+#### Parameters
+
+ * worldName : The name of the world to get (eg. "world", "world_nether", "world_the_end"
+
+#### Example
+
+ ```javascript
+ //
+ // start a storm in "world"
+ //
+ utils.getWorld("world").setStorm(true);
+ ```
+
+***/
+exports.getWorld = function( worldName ) {
+    var worldArray = server.worlds;
+    if ( worldArray instanceof java.util.Collection ) {
+        worldArray = worldArray.toArray();
+    }
+    for (var i = 0; i < worldArray.length; ++i) {
+        if (worldArray[i].name == worldName) {
+            return worldArray[i];
+        }
+    }
+    return null;
+};
+/************************************************************************
 ### utils.foreach() function
 
 The utils.foreach() function is a utility function for iterating over

--- a/src/main/js/plugins/drone/drone.js
+++ b/src/main/js/plugins/drone/drone.js
@@ -670,6 +670,8 @@ var Drone = function( x, y, z, dir, world ) {
 };
 
 exports.Drone = Drone;
+
+
 /* 
  because this is a plugin, any of its exports will be exported globally.
  Since 'blocks' is a module not a plugin it is convenient to export it via 
@@ -735,6 +737,32 @@ Drone.extend = function( name, func ) {
     return result;
   };
 };
+
+var _lookAt = function() {
+    return new Drone();
+};
+
+var _atPlayer = function(player) {
+    return new Drone(utils.getPlayerPos(player));
+};
+
+var _here = function() {
+    var player = (typeof self !== 'undefined' ? self : null);
+    if (player) {
+        return _atPlayer(player);
+    }
+    else {
+        return null;
+    }
+};
+
+/*
+* Handy ways to start a drone... here().firework();  or atPlayer("herobrine").cylinder0(blocks.stone,5,5);
+*/
+Drone.extend('lookAt',_lookAt);
+Drone.extend('atPlayer',_atPlayer);
+Drone.extend('here',_here);
+
 
 /**************************************************************************
 ### Drone.times() Method


### PR DESCRIPTION
Adds "getWorld(name)" to utils so you can do something like "utils.getWorld("world").setStorm(true);" to turn on storms in the world named "world".

Also added some handy ways to start a drone: here(), lookAt(), and atPlayer(name).  eg. "here().firework()" to start a firework where you are, or atPlayer("herobrine").cylinder0(blocks.stone,5,5); to lock Herobrine in a tower.
