### PR TITLE
that -> this

### DIFF
--- a/src/main/js/plugins/drone/stairs.js
+++ b/src/main/js/plugins/drone/stairs.js
@@ -45,7 +45,7 @@ function stairs(blockType, width, height){
 	  // 1.8
 	  var prop = require('blockhelper').property;
 	  var block = this.getBlock();
-	  prop(block).set('facing',that.dir);
+	  prop(block).set('facing',this.dir);
 	  block.update();
 	}
     });


### PR DESCRIPTION
[Originally there was a `var that = this` declaration](https://github.com/walterhiggins/ScriptCraft/commit/8056da0d3b8699dcad82c921dd26894ffc0d26a1#diff-620a3fa8f1a37223e9afbdfb5d2479a6R1227) that was taken out as part of the breakout of Drone pieces. This cleans up the final `that` which is currently present.
