### PR TITLE
Changes to allow cylinders - and other cuboids - to go down

### DIFF
--- a/src/main/js/modules/drone/index.js
+++ b/src/main/js/modules/drone/index.js
@@ -868,8 +868,15 @@ _traverse[3].width = walkDepthEast;
 _traverse[3].depth = walkWidthWest;
 function traverseHeight( drone,n,callback ) { 
   var s = drone.y, e = s + n;
-  for ( ; drone.y < e; drone.y++ ) { 
-    callback.call(drone, drone.y-s );
+  if(n > 0) {
+	  for ( ; drone.y < e; drone.y++ ) { 
+	    callback.call(drone, drone.y-s );
+	  }
+  }
+  if(n < 0) {
+	  for ( ; drone.y > e; drone.y-- ) { 
+	    callback.call(drone, drone.y-s );
+	  }
   }
   drone.y = s;
 };


### PR DESCRIPTION
Hi Walter,

   I was trying to create a new function like cylinder.js but that would create a hole in the ground. I traced cylinder --> arcImpl down to traverseHeight and noticed I could not pass a negative height in.

Would love some feedback on whether this approach makes sense or if you would do something different.

With this change I can now do
```/js cylinder(blocks.air,5,-40) ```

to make a hole with radius 5 and 40 blocks deep

Best,

-Frank