### PR TITLE
Update API-Reference.md

### DIFF
--- a/docs/API-Reference.md
+++ b/docs/API-Reference.md
@@ -5827,8 +5827,8 @@ Allows in-game operators to easily spawn creatures at current location.
 This command supports TAB completion so to see a list of possible
 entitities, type `/jsp spawn ' at the in-game command prompt, then
 press TAB. Visit
-<https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/EntityType.html> (CanaryMod)
-or <http://docs.visualillusionsent.net/CanaryLib/1.0.0/net/canarymod/api/entity/EntityType.html> (Bukkit)
+<https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/EntityType.html> (Bukkit)
+or <http://docs.visualillusionsent.net/CanaryLib/1.0.0/net/canarymod/api/entity/EntityType.html> (CanaryMod)
 
 for a list of possible entities (creatures) which can be spawned.
 


### PR DESCRIPTION
fix spawn entities lists URLs for Bukkit and CanarayMod (they were reversed)