### PR TITLE
Put example js file in classroom player directory.

### DIFF
--- a/src/main/js/modules/classroom/index.js
+++ b/src/main/js/modules/classroom/index.js
@@ -166,8 +166,19 @@ function grantScripting( player ) {
   console.log('Enabling scripting for player ' + player.name);
   var playerName = '' + player.name;
   playerName = playerName.replace(/[^a-zA-Z0-9_\-]/g,'');
+
   var playerDir = new File( playersDir + playerName );
-  playerDir.mkdirs();
+  if (!playerDir.exists()) {
+    playerDir.mkdirs();
+    var exampleJs = "//Try running this function from Minecraft with: /js $username.hi( self )\n" +
+        "//Remember to use your real username instead of $username!\n" +
+        "//So if you had username 'walterh', you would run: /js walterh.hi( self )\n" +
+        "exports.hi = function( player ){\n" +
+        "\techo( player, 'Hi ' + player.name);\n" +
+        "};"
+    createFile(playerDir, 'greet.js', exampleJs);
+  }
+
   if (__plugin.bukkit){
     player.addAttachment( __plugin, 'scriptcraft.*', true );
   }
@@ -187,6 +198,12 @@ function grantScripting( player ) {
     } 
     autoloadTime[playerName] = currentTime;
   });
+
+  function createFile(fileDir, fileName, fileContent) {
+    var out = new java.io.PrintWriter(new File(fileDir, fileName));
+    out.println(fileContent);
+    out.close();
+  }
 
 /*
   echo( player, 'Create your own minecraft mods by adding javascript (.js) files');


### PR DESCRIPTION
**What does this PR do?**

This PR augments classroom-mode behaviour. When a new directory is created for a player, an example javascript file is now also created in this directory. The file is called "greet.js" and contains:
```
//Try running this function from Minecraft with: /js $username.hi( self )
//Remember to use your real username instead of $username!
//So if you had username 'walterh', you would run: /js walterh.hi( self )
exports.hi = function( player ){
	echo( player, 'Hi ' + player.name);
};
```

This filename and content match the example discussed in the classroom.js comments.

**Why make this change?**

We used Scriptcraft classroom-mode at CoderDojo Stirling with a bunch of enthusiastic but non-technical kids.

Setup was pretty challenging, as the kids had to wrap their heads round:
* opening the samba-share of the remote players dir
* copying a js file from their laptop into the remote player dir
* opening, editing and saving this remote js file
* running the js code from the minecraft client

Things went better the second time round, when we ensured there was a js file in-place in their remote player dir (i.e. this PR). So, setup became:
* opening the samba-share of the remote players dir
* opening, editing and saving the in-place js file in the remote player dir
* running the js code from the minecraft client

**Have you tested the change?**

The change has been tested by hand for these cases:
* Blew away remote player dir on minecraft server, logged in as new player, and ensured greet.js existed in remote player dir
* Deleted greet.js from remote player dir, logged in as existing player, and ensured greet.js wasn't recreated.

Many thanks for Scriptcraft - it's awesome!

Cheers

Greg
CoderDojo Stirling



 