### PR TITLE
Fixes incompatibility where utils.players always returns [ ]

### DIFF
--- a/src/main/js/modules/utils/utils.js
+++ b/src/main/js/modules/utils/utils.js
@@ -610,8 +610,9 @@ This function returns a javascript array of player names (as javascript strings)
 ***/
 function getPlayersBukkit(){
   var result = [];
-  for (var i = 0; i < server.onlinePlayers.length; i++){
-    result.push(server.onlinePlayers[i]);
+  var players = server.getOnlinePlayers();
+  for (var i = 0; i < players.size(); i++){
+    result.push(players.get(i));
   }
   return result;
 }


### PR DESCRIPTION
Using spigot 1.8.8, utils.players() always returns empty due to usage of deprecated calls.

This fixes it on my machine, but not tested on other 'bukkit' servers.