### PR TITLE
Fixed bukkit version of recipes.js module

### DIFF
--- a/src/main/js/modules/bukkit/recipes.js
+++ b/src/main/js/modules/bukkit/recipes.js
@@ -3,9 +3,9 @@ var bkShapedRecipe = org.bukkit.inventory.ShapedRecipe;
 
 exports.add = function( recipe ){
   var result = new bkShapedRecipe( recipe.result );
-  result.shape( recipe.shape );
+  result.shape(recipe.shape[0], recipe.shape[1], recipe.shape[2]);
   for (var i in recipe.ingredients ){
-    result.setIngredient( i, recipe.ingredients[i] );
+    result.setIngredient( new java.lang.Character(i), recipe.ingredients[i].getData() );
   }
   server.addRecipe(result);
   return result;


### PR DESCRIPTION
I was having trouble adding recipes to my bukkit server using ScriptCraft.  It looks like the example in js/modules/recipes.js only works on a CanaryMod server, and the original version of js/modules/bukkit/recipes.js caused type related errors and didn't seem to implement Spigot/Bukkit methods properly.  With these changes I can now create a custom recipe and add it to the server with the following (note that the recipes.add() function both creates a bukkit ShapedRecipe AND adds the recipe to the server):

var items = require("items");
var recipes = require("recipes");
var events = require("events");

var bow = items.bow(1);
var tnt = items.tnt(1);
var explodeBow = items.bow(1);

var explodeBowMeta = explodeBow.getItemMeta();
explodeBowMeta.setDisplayName("Bow of Exploding");
explodeBowMeta.setLore(["Excite. Very boom."]);
explodeBow.setItemMeta(explodeBowMeta);

var explodeBowRecipe = recipes.add(
{
    result: explodeBow,
    ingredients: {B: bow, T: tnt},
    shape: ["   ", "TB ", "   "]
});