### PR TITLE
Added world-type=FLAT in young person's guide

### DIFF
--- a/docs/YoungPersonsGuideToProgrammingMinecraft.md
+++ b/docs/YoungPersonsGuideToProgrammingMinecraft.md
@@ -135,6 +135,7 @@ Once you've installed CanaryMod, depending on your specific needs,
 you might want to consider setting the following properties in the `server.cfg` or `config/worlds/<worldName>/<worldName>.cfg` files ...
 
     # completely flat worlds are best for building from scratch
+    world-type=FLAT
     level-type=FLAT
     generate-structures=false
     


### PR DESCRIPTION
In trying to get the generated world to be flat, the level-type=FLAT didn't work, but world-type=FLAT worked.