### PR TITLE
Fixed a typo in entities.js

### DIFF
--- a/src/main/js/plugins/entities.js
+++ b/src/main/js/plugins/entities.js
@@ -1,5 +1,5 @@
 'use strict';
-/*global reuire, exports*/
+/*global require, exports*/
 /* 
  make entities a global variable for use at in-game prompt 
  Tab completion is a useful way to discover what entity types are available.


### PR DESCRIPTION
Fixed a typo in **entities.js** in which a comment said `reuire` instead of `require`
