### PR TITLE
Fixed updatePlayerScore correctly update the score

### DIFF
--- a/src/main/js/modules/minigames/scoreboard.js
+++ b/src/main/js/modules/minigames/scoreboard.js
@@ -55,7 +55,7 @@ function updatePlayerScore( objectiveName, playerName, score ){
    var sc = sb['getScore(String, ScoreObjective)']( playerName, sb.getScoreObjective( objectiveName) );
    sc.score = score;
    */
-  execCommand('scoreboard players set ' + playerName + ' ' + objectiveName + score);
+  execCommand('scoreboard players set ' + playerName + ' ' + objectiveName + ' ' + score);
 }
 
 function removeTeamFromScoreboard( teamName ){


### PR DESCRIPTION
ObjectiveName and score were merged in a single field, causing the update not to happen.
