### PR TITLE
Fix broken heading #introduction

### DIFF
--- a/docs/YoungPersonsGuideToProgrammingMinecraft.md
+++ b/docs/YoungPersonsGuideToProgrammingMinecraft.md
@@ -43,6 +43,7 @@ If you would like to make changes, change file src/docs/templates/ypgpm.md inste
  * [Keeping Score - Lookup tables in Javascript](#keeping-score---lookup-tables-in-javascript)
  * [Counting block break events for each player](#counting-block-break-events-for-each-player)
  * [Next Steps](#next-steps)
+
 ## Introduction
 
 Minecraft is an open-ended 3D game where you can build and craft


### PR DESCRIPTION
I noticed that the "introduction" heading and it's named anchor link were broken. This should fix it.