### PR TITLE
Allow a Drone to be created from the location and direction of another Drone

### DIFF
--- a/src/main/js/modules/drone/index.js
+++ b/src/main/js/modules/drone/index.js
@@ -398,6 +398,12 @@ function Drone( x, y, z, dir, world ) {
       }
       populateFromLocation( playerPos );
     }
+  } else if ( x instanceof Drone ) {
+    this.x = x.x;
+    this.y = x.y;
+    this.z = x.z;
+    this.dir = x.dir;
+    this.world = x.world;
   } else {
     if ( arguments[0].x && arguments[0].y && arguments[0].z ) {
       populateFromLocation( arguments[ 0 ] );


### PR DESCRIPTION
In my pursuit for creating more comprehensive worlds I need to be able to spin Drones off from the current position of another Drone without affecting the first one in any way.