### PR TITLE
Return unregister() handler when registering classroom events

### DIFF
--- a/src/main/js/modules/classroom/index.js
+++ b/src/main/js/modules/classroom/index.js
@@ -157,6 +157,7 @@ function reloadPlayerModules( playerContext, playerDir ){
   var newOn = function( eventType, fn, priority){
     var handler = oldOn(eventType, fn, priority);
     eventHandlers.push(handler);
+    return handler;
   };
   events.on = newOn;
   autoload( playerContext, playerDir, { cache: false });


### PR DESCRIPTION
When using events in classroom mode, students are unable to unregister their listeners from outside the listener function. 

This change returns the object with `.unregister()` from the wrapped `events.on()` function for classroom plugins.