### PR TITLE
Fix watcher last modified comparison

### DIFF
--- a/src/main/js/modules/watcher.js
+++ b/src/main/js/modules/watcher.js
@@ -147,7 +147,7 @@ function fileWatcher(calledCallbacks) {
   for (var file in filesWatched) {
     var fileObject = new File(file);
     var lm = fileObject.lastModified();
-    if ( lm != filesWatched[file].lastModified ) {
+    if ( String(lm) != String(filesWatched[file].lastModified) ) {
       filesWatched[file].lastModified = lm;
       filesWatched[file].callback(fileObject);
       if (!fileObject.exists()) {
@@ -166,7 +166,7 @@ function dirWatcher(calledCallbacks) {
     var dirObject = new File(dir);
     var lm = dirObject.lastModified();
     var dw = dirsWatched[dir];
-    if ( lm != dirsWatched[dir].lastModified ) {
+    if ( String(lm) != String(dirsWatched[dir].lastModified) ) {
       dirsWatched[dir].lastModified = lm;
       dirsWatched[dir].callback(dirObject);
       


### PR DESCRIPTION
The file/directory watcher is firing the changed callback when the file or directory has not changed. This affects classroom mode causing all player plugins to be reloaded every 3 seconds. 

The current lastModified check is comparing objects (which will always result in `!=` not equals). This fix casts the lastModified objects to string to compare the timestamps as strings.