### PR TITLE
Remove oraclejdk7 from .travis.yml as Travis does not support it anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: java
 jdk:
   - oraclejdk8
-  - oraclejdk7
   - openjdk7


### PR DESCRIPTION
See
https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879

No big loss as `openjdk7` still works. This should fix the currently red build status.