### PR TITLE
Minimal fix for Drone in 1.13

### DIFF
--- a/src/main/js/modules/drone/index.js
+++ b/src/main/js/modules/drone/index.js
@@ -326,6 +326,33 @@ function getDirFromRotation(location) {
   if (r > 225 && r <= 315) return 0; // east
   return 1; // south
 }
+
+var setTypeIdAndData = makeTypeIdAndDataSetter();
+
+function makeTypeIdAndDataSetter() {
+  if (!__plugin.bukkit) {
+    return null;
+  }
+
+  var Block = Java.type('org.bukkit.block.Block');
+  if (
+    Java.from(Block.class.methods).some(function(m) {
+      return m.name == 'setTypeIdAndData';
+    })
+  ) {
+    console.log('Drone using Block.setTypeIdAndData method');
+    return function(block, typeId, data, applyPhysics) {
+      block.setTypeIdAndData(typeId, data, applyPhysics);
+    };
+  } else {
+    console.log('Drone using CraftEvil.setTypeIdAndData method');
+    var CraftEvil = Java.type(server.class.package.name + '.util.CraftEvil');
+    return function(block, typeId, data, applyPhysics) {
+      CraftEvil.setTypeIdAndData(block, typeId, data, applyPhysics);
+    };
+  }
+}
+
 /*
  low-level function to place a block in the world - all drone methods which 
  place blocks ultimately invoke this function.
@@ -349,8 +376,7 @@ function putBlock(x, y, z, blockId, metadata, world, update) {
     }
   }
   if (__plugin.bukkit) {
-    block.setTypeIdAndData(blockId, metadata, false);
-    block.data = metadata;
+    setTypeIdAndData(block, blockId, metadata, update);
   }
   return block;
 }


### PR DESCRIPTION
The deprecated Block.setTypeIdAndData method that the Drone was using was finally removed from the Bukkit API as part of the 1.13 update. There is no longer a method on the Block interface that can work with the old numeric block IDs.

Fortunately, CraftBukkit/Spigot now has a `CraftEvil` class offering a static `setTypeIdAndData` method that maps the old IDs to the new API. It is definitely not future-proof but allows us to run on 1.13 until we come up with a way to use the more recent API without breaking a lot of existing ScriptCraft code.

This patch simply detects when the `Block.setTypeIdAndData` is missing and tries to use the `CraftEvil` class instead.

Probably not a complete fix for #349, but at least it lets you run ScriptCraft reasonably under 1.13 today.