### PR TITLE
Fix issue #390

### DIFF
--- a/src/main/js/lib/tabcomplete.js
+++ b/src/main/js/lib/tabcomplete.js
@@ -163,6 +163,7 @@ var onTabCompleteJS = function() {
     //
     parts = lastSymbol.split(/\./);
     name = parts[0];
+    if (name == '') return; // fix issue #390
 
     symbol = global[name];
 


### PR DESCRIPTION
Ignore if the part of the last symbol is empty.

The "java.lang.IllegalArgumentException: name cannot be empty" problem existed prior to Minecraft 1.13, but it only showed up when you press Tab.  In 1.13, onTabComplete is called each time you type a character in the Minecraft console so the problem becomes prevalent.