### PR TITLE
Fix for 1.13 on /js refresh()

### DIFF
--- a/src/main/js/lib/scriptcraft.js
+++ b/src/main/js/lib/scriptcraft.js
@@ -575,7 +575,7 @@ function __onEnable(__engine, __plugin, __script) {
       Canary.manager().enablePlugin(pluginName);
     } else {
       __plugin.pluginLoader.disablePlugin(__plugin);
-      org.bukkit.event.HandlerList.unregisterAll(__plugin);
+      org.bukkit.event.HandlerList['unregisterAll(org.bukkit.plugin.Plugin)'](__plugin);
       server.scheduler.cancelTasks(__plugin);
       __plugin.pluginLoader.enablePlugin(__plugin);
     }


### PR DESCRIPTION
Another one of these "can't unambiguously select method for fixed arity signature" thing-o's.

Shout out to @jwulf !