### PR TITLE
Gracefully fail drone module on 1.15.2+

### DIFF
--- a/src/main/js/modules/drone/index.js
+++ b/src/main/js/modules/drone/index.js
@@ -353,12 +353,11 @@ function makeTypeIdAndDataSetter() {
       };
     } catch (e) {
       console.log(
-        'Drone not available on this server - no setTypeIdAndData support'
+        'Drone support is experimental on 1.15.2 and above, and may be broken...'
       );
       return function(block, typeId, data, applyPhysics) {
-        throw new Error(
-          `Drone not supported on versions > 1.15.1 - no setTypeIdAndData support`
-        );
+        block.setBlockData(data, applyPhysics);
+        block.setType(typeId);
       };
     }
   }

--- a/src/main/js/modules/drone/index.js
+++ b/src/main/js/modules/drone/index.js
@@ -345,11 +345,22 @@ function makeTypeIdAndDataSetter() {
       block.setTypeIdAndData(typeId, data, applyPhysics);
     };
   } else {
-    console.log('Drone using CraftEvil.setTypeIdAndData method');
-    var CraftEvil = Java.type(server.class.package.name + '.util.CraftEvil');
-    return function(block, typeId, data, applyPhysics) {
-      CraftEvil.setTypeIdAndData(block, typeId, data, applyPhysics);
-    };
+    try {
+      var CraftEvil = Java.type(server.class.package.name + '.util.CraftEvil');
+      console.log('Drone using CraftEvil.setTypeIdAndData method');
+      return function(block, typeId, data, applyPhysics) {
+        CraftEvil.setTypeIdAndData(block, typeId, data, applyPhysics);
+      };
+    } catch (e) {
+      console.log(
+        'Drone not available on this server - no setTypeIdAndData support'
+      );
+      return function(block, typeId, data, applyPhysics) {
+        throw new Error(
+          `Drone not supported on versions > 1.15.1 - no setTypeIdAndData support`
+        );
+      };
+    }
   }
 }
 


### PR DESCRIPTION
Gracefully fail the drone module with a helpful message on 1.15.2 while we figure out how to reimplement support on the new Block API.